### PR TITLE
Added Pawn-Package Definition file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+# Compiled Bytecode
+*.amx
+
+# Vendor directory for dependencies
+dependencies/
+
+# Dependency versions lockfile
+pawn.lock

--- a/pawn.json
+++ b/pawn.json
@@ -1,0 +1,11 @@
+{
+    "entry": "test.pwn",
+    "output": "test.amx",
+    "dependencies": [
+        "Southclaws/samp-stdlib",
+        "Zeex/amx_assembly",
+        "Misiur/YSI-Includes",
+
+        "ScavengeSurvive/test-boilerplate"
+    ]
+}

--- a/test.pwn
+++ b/test.pwn
@@ -1,0 +1,17 @@
+#include "trafficlights.inc"
+
+main() {
+    new light = CreateTrafficLight(TL_TYPE_1, 0.0, 0.0, 4.0, 0.0, 0.0, 0.0);
+    SetTrafficLightColor(light, TLC_RED);
+    GetTrafficLightColor(light);
+    DisableTrafficLight(light);
+    RemoveTrafficLight(light);
+    RemoveAllTrafficLights();
+    GetPostRequiredLights(TL_TYPE_1);
+    GetPostOffsetsIndex(TL_TYPE_1);
+    CheckPostUpperLight(TL_TYPE_1);
+    IsValidTrafficLightColor(TLC_GREEN);
+    IsValidTrafficLightPost(TL_TYPE_1);
+    // no 0.3.8 in sampctl tests yet
+    // LoadTrafficLightsModels();
+}


### PR DESCRIPTION
Since [sampctl](https://github.com/Southclaws/sampctl) is getting to the point where it's production-ready, I'm encouraging people to start using it while developing libraries as it should make the process of testing and developing a lot smoother. It's designed so you don't need a `pawn.json`/`pawn.yaml` ("Pawn-Package Definition" file) in every repo, but having it there really helps with dependency management! These changes are purely additive and do not change your code or scripting style in any way, you don't need to use sampctl yourself but I encourage you to [give it a try](https://github.com/Southclaws/sampctl/wiki#installation)!

- added sampctl package files for version control, so a user could now simply run `sampctl package install RIDE-2DAY/TrafficLights` to start using this library in their gamemode which would automatically pull in YSI and other dependencies.

- also added a test entry point which doesn't do much other than contain a call for each function in order to test compilation - this could be improved with y_testing or just simple in-game tests - this allows you do forget about setting up a server/gamemode etc and just run `sampctl package run` and connect to `localhost:7777` to test the library.